### PR TITLE
Implemented EPHIN5/EPHIN15 data reading and onset tool compatibility.

### DIFF
--- a/seppy/tools/__init__.py
+++ b/seppy/tools/__init__.py
@@ -228,7 +228,7 @@ class Event:
 
                 df = pd.read_csv(f"{self.data_path}{os.sep}{dataset}", usecols=datacols,
                                     index_col="date", parse_dates=True)
-                meta = {"E5": "0.45 - 050 MeV",
+                meta = {"E5": "0.45 - 0.50 MeV",
                         "E15": "0.70 - 1.10 MeV"}
 
                 self.update_viewing(viewing)


### PR DESCRIPTION
Use either sensor="EPHIN-5" or sensor="EPHIN-15" to load the Histogram data product to the Event object. 
Event.print_energies() shows the two available channel indices (5 and 15) and their corresponding energy ranges.
Event.find_onset() works as usual with the input described in this pull request.