### PR TITLE
outsource FILLVAL replace to sunpy (fixes #11)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ pandas
 pooch
 requests
 solo-epd-loader
-sunpy>=4.0.0
+sunpy>=4.1.0
 zeep

--- a/seppy/loader/psp.py
+++ b/seppy/loader/psp.py
@@ -261,7 +261,11 @@ def psp_isois_load(dataset, startdate, enddate, epilo_channel='F', epilo_thresho
             # remove this (i.e. following line) when sunpy's read_cdf is updated,
             # and FILLVAL will be replaced directly, see
             # https://github.com/sunpy/sunpy/issues/5908
-            df = df.replace(cdf.varattsget('A_H_Flux')['FILLVAL'], np.nan)
+            # df = df.replace(cdf.varattsget('A_H_Flux')['FILLVAL'], np.nan)
+            # 4 Apr 2023: previous 1 lines removed because they are taken care of with sunpy
+            # 4.1.0:
+            # https://docs.sunpy.org/en/stable/whatsnew/changelog.html#id7
+            # https://github.com/sunpy/sunpy/pull/5956
 
             # get info on energies and units
             energies_dict = {"H_ENERGY":

--- a/seppy/loader/soho.py
+++ b/seppy/loader/soho.py
@@ -137,8 +137,12 @@ def soho_load(dataset, startdate, enddate, path=None, resample=None, pos_timesta
             # remove this (i.e. following lines) when sunpy's read_cdf is updated,
             # and FILLVAL will be replaced directly, see
             # https://github.com/sunpy/sunpy/issues/5908
-            df = df.replace(-1e+31, np.nan)  # for all fluxes
-            df = df.replace(-2147483648, np.nan)  # for ERNE count rates
+            # df = df.replace(-1e+31, np.nan)  # for all fluxes
+            # df = df.replace(-2147483648, np.nan)  # for ERNE count rates
+            # 4 Apr 2023: previous 2 lines removed because they are taken care of with sunpy
+            # 4.1.0:
+            # https://docs.sunpy.org/en/stable/whatsnew/changelog.html#id7
+            # https://github.com/sunpy/sunpy/pull/5956
 
             # careful!
             # adjusting the position of the timestamp manually.

--- a/seppy/loader/stereo.py
+++ b/seppy/loader/stereo.py
@@ -397,15 +397,19 @@ def stereo_load(instrument, startdate, enddate, spacecraft='ahead', mag_coord='R
             # TODO: remove this (i.e. following two lines) when sunpy's
             # read_cdf is updated, and FILLVAL will be replaced directly, see
             # https://github.com/sunpy/sunpy/issues/5908
-            if instrument.upper() == 'HET':
-                df = df.replace(metadata['Electron_Flux_FILLVAL'], np.nan)
-            if instrument.upper() == 'LET':
-                df = df.replace(-1e+31, np.nan)
-                df = df.replace(-2147483648, np.nan)
-            if instrument.upper() == 'MAG':
-                df = df.replace(-1e+31, np.nan)
-            if instrument.upper() == 'MAGPLASMA':
-                df = df.replace(-1.0e+30, np.nan)
+            # if instrument.upper() == 'HET':
+            #     df = df.replace(metadata['Electron_Flux_FILLVAL'], np.nan)
+            # if instrument.upper() == 'LET':
+            #     df = df.replace(-1e+31, np.nan)
+            #     df = df.replace(-2147483648, np.nan)
+            # if instrument.upper() == 'MAG':
+            #     df = df.replace(-1e+31, np.nan)
+            # if instrument.upper() == 'MAGPLASMA':
+            #     df = df.replace(-1.0e+30, np.nan)
+            # 4 Apr 2023: previous 9 lines removed because they are taken care of with sunpy
+            # 4.1.0:
+            # https://docs.sunpy.org/en/stable/whatsnew/changelog.html#id7
+            # https://github.com/sunpy/sunpy/pull/5956
 
             # Because MAGPLASMA datafiles are for full calendar years, select only
             # the requested time range from it. Using trange because startdate

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     pooch
     requests
     solo-epd-loader
-    sunpy>=4.0.0
+    sunpy>=4.1.0
     zeep
 
 


### PR DESCRIPTION
Don't replace FILLVAL's manually because since 4.1.0 this is handled by sunpy. Also fixes #11 