### PR TITLE
Patched Event.viewing setting to an incorrect value at class constructor.

### DIFF
--- a/seppy/tests/test_tools.py
+++ b/seppy/tests/test_tools.py
@@ -385,7 +385,7 @@ def test_onset_spectrum_tsa_STEREOA_SEPT_p_online():
 
     # test dynamic spectrum:
     Event1.dynamic_spectrum(view="north")
-    assert Event1.fig.get_axes()[0].get_title() == 'STA/SEPT protons, 2021-10-28'
+    assert Event1.fig.get_axes()[0].get_title() == 'STA/SEPT (north) protons, 2021-10-28'
 
     # test tsa plot:
     plt.close('all')  # in order to pick the right figure, make sure all previous are closed
@@ -412,7 +412,7 @@ def test_onset_spectrum_tsa_STEREOA_SEPT_e_online():
 
     # test dynamic spectrum:
     Event1.dynamic_spectrum(view="asun")
-    assert Event1.fig.get_axes()[0].get_title() == 'Radio & Dynamic Spectrum, STA/SEPT electrons, 2021-10-28'
+    assert Event1.fig.get_axes()[0].get_title() == 'Radio & Dynamic Spectrum, STA/SEPT (asun) electrons, 2021-10-28'
 
     # test tsa plot:
     plt.close('all')  # in order to pick the right figure, make sure all previous are closed

--- a/seppy/tests/test_tools.py
+++ b/seppy/tests/test_tools.py
@@ -384,12 +384,12 @@ def test_onset_spectrum_tsa_STEREOA_SEPT_p_online():
     assert fig.get_axes()[0].get_title() == 'STA/SEPT 110-174.6 keV protons\n5min averaging, viewing: NORTH'
 
     # test dynamic spectrum:
-    Event1.dynamic_spectrum(view=None)
+    Event1.dynamic_spectrum(view="north")
     assert Event1.fig.get_axes()[0].get_title() == 'STA/SEPT protons, 2021-10-28'
 
     # test tsa plot:
     plt.close('all')  # in order to pick the right figure, make sure all previous are closed
-    Event1.tsa_plot(None, selection=None, resample=None)
+    Event1.tsa_plot(view="north", selection=None, resample=None)
     assert plt.figure(1).get_axes()[0].get_title() == 'STEREO-A SEPT, protons'
 
 
@@ -411,12 +411,12 @@ def test_onset_spectrum_tsa_STEREOA_SEPT_e_online():
     assert fig.get_axes()[0].get_title() == 'STA/SEPT 125-145 keV electrons\n5min averaging, viewing: ASUN'
 
     # test dynamic spectrum:
-    Event1.dynamic_spectrum(view=None)
+    Event1.dynamic_spectrum(view="asun")
     assert Event1.fig.get_axes()[0].get_title() == 'Radio & Dynamic Spectrum, STA/SEPT electrons, 2021-10-28'
 
     # test tsa plot:
     plt.close('all')  # in order to pick the right figure, make sure all previous are closed
-    Event1.tsa_plot(None, selection=None, resample=None)
+    Event1.tsa_plot(view="asun", selection=None, resample=None)
     assert plt.figure(1).get_axes()[0].get_title() == 'STEREO-A SEPT, electrons'
 
 

--- a/seppy/tests/test_tools.py
+++ b/seppy/tests/test_tools.py
@@ -170,7 +170,7 @@ def test_onset_spectrum_tsa_PSP_ISOIS_EPIHI_online():
     lpath = f"{os.getcwd()}/data/"
     background_range = (datetime.datetime(2021, 10, 28, 10, 0, 0), datetime.datetime(2021, 10, 28, 12, 0, 0))
     # viewing "A", single channel, electrons
-    Event1 = Event(spacecraft='PSP', sensor='isois-epihi', data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath)
+    Event1 = Event(spacecraft='PSP', sensor='isois-epihi', viewing='A', data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath)
     print(Event1.print_energies())
     flux, onset_stats, onset_found, peak_flux, peak_time, fig, bg_mean = Event1.find_onset(viewing='A', background_range=background_range, channels=4, resample_period="5min", yscale='log', cusum_window=30)
     assert isinstance(flux, pd.Series)
@@ -181,7 +181,7 @@ def test_onset_spectrum_tsa_PSP_ISOIS_EPIHI_online():
     assert peak_time.isoformat().split('.')[0] == '2021-10-28T16:06:59'
     assert fig.get_axes()[0].get_title() == 'PSP/ISOIS-EPIHI 0.8 - 1.0 MeV electrons\n5min averaging, viewing: A'
     # viewing "B", combined channel, protons
-    Event1 = Event(spacecraft='PSP', sensor='isois-epihi', data_level='l2', species='protons', start_date=startdate, end_date=enddate, data_path=lpath)
+    Event1 = Event(spacecraft='PSP', sensor='isois-epihi', viewing='B', data_level='l2', species='protons', start_date=startdate, end_date=enddate, data_path=lpath)
     print(Event1.print_energies())
     flux, onset_stats, onset_found, peak_flux, peak_time, fig, bg_mean = Event1.find_onset(viewing='B', background_range=background_range, channels=[1, 5], resample_period="5min", yscale='log', cusum_window=30)
     assert isinstance(flux, pd.Series)
@@ -206,7 +206,7 @@ def test_onset_spectrum_tsa_PSP_ISOIS_EPILO_e_online():
     startdate = datetime.date(2021, 10, 28)
     enddate = datetime.date(2021, 10, 29)
     lpath = f"{os.getcwd()}/data/"
-    Event1 = Event(spacecraft='PSP', sensor='isois-epilo', data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath)
+    Event1 = Event(spacecraft='PSP', sensor='isois-epilo', viewing='7', data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath)
     print(Event1.print_energies())
     background_range = (datetime.datetime(2021, 10, 28, 10, 0, 0), datetime.datetime(2021, 10, 28, 12, 0, 0))
     # viewing "7", single channel
@@ -242,7 +242,7 @@ def test_onset_spectrum_tsa_Wind_3DP_p_online():
     startdate = datetime.date(2021, 10, 28)
     enddate = datetime.date(2021, 10, 29)
     lpath = f"{os.getcwd()}/data/"
-    Event1 = Event(spacecraft='Wind', sensor='3DP', data_level='l2', species='protons', start_date=startdate, end_date=enddate, data_path=lpath)
+    Event1 = Event(spacecraft='Wind', sensor='3DP', data_level='l2', viewing="Sector 3", species='protons', start_date=startdate, end_date=enddate, data_path=lpath)
     print(Event1.print_energies())
     background_range = (datetime.datetime(2021, 10, 28, 10, 0, 0), datetime.datetime(2021, 10, 28, 12, 0, 0))
     # viewng "sector 3"
@@ -279,7 +279,7 @@ def test_onset_spectrum_tsa_Wind_3DP_e_online():
     startdate = datetime.date(2021, 10, 28)
     enddate = datetime.date(2021, 10, 29)
     lpath = f"{os.getcwd()}/data/"
-    Event1 = Event(spacecraft='Wind', sensor='3DP', data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath)  # TODO: radio_spacecraft=('wind', 'WIND')
+    Event1 = Event(spacecraft='Wind', sensor='3DP', viewing="Sector 3", data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath)  # TODO: radio_spacecraft=('wind', 'WIND')
     print(Event1.print_energies())
     background_range = (datetime.datetime(2021, 10, 28, 10, 0, 0), datetime.datetime(2021, 10, 28, 12, 0, 0))
     #
@@ -370,7 +370,7 @@ def test_onset_spectrum_tsa_STEREOA_SEPT_p_online():
     startdate = datetime.date(2021, 10, 28)
     enddate = datetime.date(2021, 10, 28)
     lpath = f"{os.getcwd()}/data/"
-    Event1 = Event(spacecraft='STEREO-A', sensor='SEPT', data_level='l2', species='ions', start_date=startdate, end_date=enddate, data_path=lpath)
+    Event1 = Event(spacecraft='STEREO-A', sensor='SEPT', viewing="north", data_level='l2', species='ions', start_date=startdate, end_date=enddate, data_path=lpath)
     print(Event1.print_energies())
     background_range = (datetime.datetime(2021, 10, 28, 10, 0, 0), datetime.datetime(2021, 10, 28, 12, 0, 0))
     flux, onset_stats, onset_found, peak_flux, peak_time, fig, bg_mean = Event1.find_onset(viewing='north', background_range=background_range, channels=[5, 8], resample_period="5min", yscale='log', cusum_window=30)
@@ -397,7 +397,7 @@ def test_onset_spectrum_tsa_STEREOA_SEPT_e_online():
     startdate = datetime.date(2021, 10, 28)
     enddate = datetime.date(2021, 10, 28)
     lpath = f"{os.getcwd()}/data/"
-    Event1 = Event(spacecraft='STEREO-A', sensor='SEPT', data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath, radio_spacecraft=('ahead', 'STEREO-A'))
+    Event1 = Event(spacecraft='STEREO-A', sensor='SEPT', viewing="asun", data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath, radio_spacecraft=('ahead', 'STEREO-A'))
     print(Event1.print_energies())
     background_range = (datetime.datetime(2021, 10, 28, 10, 0, 0), datetime.datetime(2021, 10, 28, 12, 0, 0))
     flux, onset_stats, onset_found, peak_flux, peak_time, fig, bg_mean = Event1.find_onset(viewing='asun', background_range=background_range, channels=[8], resample_period="5min", yscale='log', cusum_window=30)

--- a/seppy/tools/__init__.py
+++ b/seppy/tools/__init__.py
@@ -63,7 +63,9 @@ class Event:
         self.data_path = data_path + os.sep
         self.threshold = threshold
         self.radio_spacecraft = radio_spacecraft  # this is a 2-tuple, e.g., ("ahead", "STEREO-A")
-        self.viewing = viewing
+
+        # Sets the self.viewing to the given viewing
+        self.update_viewing(viewing=viewing)
 
         self.radio_files = None
 
@@ -174,7 +176,7 @@ class Event:
                                             enddate=self.end_date,
                                             path=self.data_path,
                                             autodownload=autodownload)
-                # self.update_viewing(viewing) Why is viewing updated here?
+
                 return df_i, df_e, meta
 
             elif self.sensor == "step":
@@ -186,7 +188,6 @@ class Event:
                                     path=self.data_path,
                                     autodownload=autodownload)
 
-                # self.update_viewing(viewing) Why is viewing updated here?
                 return df, meta
 
         if self.spacecraft[:2].lower() == 'st':
@@ -204,7 +205,6 @@ class Event:
                                                            path=self.data_path)
                     df_e, channels_dict_df_e = [], []
 
-                    self.update_viewing(viewing)
                     return df_i, df_e, channels_dict_df_i, channels_dict_df_e
 
                 if self.species == "e":
@@ -221,7 +221,6 @@ class Event:
 
                     df_i, channels_dict_df_i = [], []
 
-                    self.update_viewing(viewing)
                     return df_i, df_e, channels_dict_df_i, channels_dict_df_e
 
             if self.sensor == 'het':
@@ -233,7 +232,6 @@ class Event:
                                        pos_timestamp="center",
                                        path=self.data_path)
 
-                self.update_viewing(viewing)
                 return df, meta
 
         if self.spacecraft.lower() == 'soho':
@@ -245,7 +243,6 @@ class Event:
                                      resample=None,
                                      pos_timestamp="center")
 
-                self.update_viewing(viewing)
                 return df, meta
 
             if self.sensor == 'ephin':
@@ -256,7 +253,6 @@ class Event:
                                      resample=None,
                                      pos_timestamp="center")
 
-                self.update_viewing(viewing)
                 return df, meta
 
             if self.sensor in ("ephin-5", "ephin-15"):
@@ -277,7 +273,6 @@ class Event:
                 # - add resample_df here?
                 # - add pos_timestamp here
 
-                self.update_viewing(viewing)
                 return df, meta
 
         if self.spacecraft.lower() == 'wind':
@@ -320,7 +315,6 @@ class Event:
                                                       path=self.data_path,
                                                       threshold=self.threshold)
 
-                self.update_viewing(viewing)
                 return df_omni_i, df_omni_e, df_i, df_e, meta_i, meta_e
 
         if self.spacecraft.lower() == 'psp':
@@ -331,7 +325,6 @@ class Event:
                                           path=self.data_path,
                                           resample=None)
 
-                self.update_viewing(viewing)
                 return df, meta
             if self.sensor.lower() == 'isois-epilo':
                 df, meta = psp_isois_load(dataset='PSP_ISOIS-EPILO_L2-PE',
@@ -342,7 +335,6 @@ class Event:
                                           epilo_channel='F',
                                           epilo_threshold=self.threshold)
 
-                self.update_viewing(viewing)
                 return df, meta
 
         if self.spacecraft.lower() == 'bepi':


### PR DESCRIPTION
- Event.viewing must now be provided explicitly for spacecraft/instrument combinations that have different viewing directions.
- viewing validity is checked in Event.update_viewing(), that is ran at object init.
- Added constant VIEWINGS tuples containing all the valid viewing names for instruments that have viewings.
- Updated tests.