### PR TITLE
Refactor sqrt_sum_squares to propagated_mean_uncertainty function. Refactor SEPT energy channel definition (internal).

### DIFF
--- a/seppy/loader/stereo.py
+++ b/seppy/loader/stereo.py
@@ -125,23 +125,45 @@ def stereo_sept_loader(startdate, enddate, spacecraft, species, viewing, resampl
         spacecraft = 'behind'
 
     # channel dicts from Nina:
-    ch_strings = ['45.0-55.0 keV', '55.0-65.0 keV', '65.0-75.0 keV', '75.0-85.0 keV', '85.0-105.0 keV', '105.0-125.0 keV', '125.0-145.0 keV', '145.0-165.0 keV', '165.0-195.0 keV', '195.0-225.0 keV', '225.0-255.0 keV', '255.0-295.0 keV', '295.0-335.0 keV', '335.0-375.0 keV', '375.0-425.0 keV']
-    mean_E = []
-    for i in range(len(ch_strings)):
-        temp  = ch_strings[i].split(' keV')
+    e_ch_strings = ['45.0-55.0 keV', '55.0-65.0 keV', '65.0-75.0 keV', '75.0-85.0 keV', '85.0-105.0 keV', '105.0-125.0 keV', '125.0-145.0 keV', '145.0-165.0 keV', '165.0-195.0 keV', '195.0-225.0 keV', '225.0-255.0 keV', '255.0-295.0 keV', '295.0-335.0 keV', '335.0-375.0 keV', '375.0-425.0 keV']
+    e_lower_E = []
+    e_upper_E = []
+    e_mean_E = []
+    for i in range(len(e_ch_strings)):
+        temp  = e_ch_strings[i].split(' keV')
         clims = temp[0].split('-')
         lower = float(clims[0])
         upper = float(clims[1])
-        mean_E.append(np.sqrt(upper*lower))
+        e_lower_E.append(lower)
+        e_upper_E.append(upper)
+        e_mean_E.append(np.sqrt(upper*lower))
     #
     echannels = {'bins': [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-                 'ch_strings': ch_strings,
+                 'ch_strings': e_ch_strings,
                  'DE': [0.0100, 0.0100, 0.0100, 0.0100, 0.0200, 0.0200, 0.0200, 0.0200, 0.0300, 0.0300, 0.0300, 0.0400, 0.0400, 0.0400, 0.0500],
-                 'mean_E': np.array(mean_E)/1000.}
+                 'lower_E': np.array(e_lower_E)/1000.,
+                 'upper_E': np.array(e_upper_E)/1000.,
+                 'mean_E': np.array(e_mean_E)/1000.}
+
+    p_ch_strings = ['84.1-92.7 keV', '92.7-101.3 keV', '101.3-110.0 keV', '110.0-118.6 keV', '118.6-137.0 keV', '137.0-155.8 keV', '155.8-174.6 keV', '174.6-192.6 keV', '192.6-219.5 keV', '219.5-246.4 keV', '246.4-273.4 keV', ' 273.4-312.0 keV', '312.0-350.7 keV', '350.7-389.5 keV', '389.5-438.1 keV', '438.1-496.4 keV', '496.4-554.8 keV', ' 554.8-622.9 keV', '622.9-700.7 keV', '700.7-788.3 keV', '788.3-875.8 keV', '875.8- 982.8 keV', '982.8-1111.9 keV', '1111.9-1250.8 keV', '1250.8-1399.7 keV', '1399.7-1578.4 keV', '1578.4-1767.0 keV', '1767.0-1985.3 keV', '1985.3-2223.6 keV', '2223.6-6500.0 keV']
+    p_lower_E = []
+    p_upper_E = []
+    p_mean_E = []
+    for i in range(len(p_ch_strings)):
+        temp  = p_ch_strings[i].split(' keV')
+        clims = temp[0].split('-')
+        lower = float(clims[0])
+        upper = float(clims[1])
+        p_lower_E.append(lower)
+        p_upper_E.append(upper)
+        p_mean_E.append(np.sqrt(upper*lower))
+
     pchannels = {'bins': [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
-                 'ch_strings': ['84.1-92.7 keV', '92.7-101.3 keV', '101.3-110.0 keV', '110.0-118.6 keV', '118.6-137.0 keV', '137.0-155.8 keV', '155.8-174.6 keV', '174.6-192.6 keV', '192.6-219.5 keV', '219.5-246.4 keV', '246.4-273.4 keV', ' 273.4-312.0 keV', '312.0-350.7 keV', '350.7-389.5 keV', '389.5-438.1 keV', '438.1-496.4 keV', '496.4-554.8 keV', ' 554.8-622.9 keV', '622.9-700.7 keV', '700.7-788.3 keV', '788.3-875.8 keV', '875.8- 982.8 keV', '982.8-1111.9 keV', '1111.9-1250.8 keV', '1250.8-1399.7 keV', '1399.7-1578.4 keV', '1578.4-1767.0 keV', '1767.0-1985.3 keV', '1985.3-2223.6 keV', '2223.6-6500.0 keV'],
+                 'ch_strings': p_ch_strings,
                  'DE': [0.0086, 0.0086, 0.0087, 0.0086, 0.0184, 0.0188, 0.0188, 0.018, 0.0269, 0.0269, 0.027, 0.0386, 0.0387, 0.0388, 0.0486, 0.0583, 0.0584, 0.0681, 0.0778, 0.0876, 0.0875, 0.107, 0.1291, 0.1389, 0.1489, 0.1787, 0.1886, 0.2183, 0.2383, 4.2764],
-                 'mean_E': np.array([88.30, 96.90, 105.56, 114.22, 127.47, 146.10, 164.93, 183.38, 205.61, 232.56, 259.55, 292.06, 330.78, 369.59, 413.09, 466.34, 524.79, 587.86, 660.66, 743.21, 830.90, 927.76, 1045.36, 1179.31, 1323.16, 1486.37, 1670.04, 1872.97, 2101.07, 3801.76])/1000.}
+                 'lower_E': np.array(p_lower_E)/1000.,
+                 'upper_E': np.array(p_upper_E)/1000.,
+                 'mean_E': np.array(p_mean_E)/1000.}
     # :channel dicts from Nina
 
     if species == 'ele':

--- a/seppy/util/__init__.py
+++ b/seppy/util/__init__.py
@@ -13,6 +13,7 @@ import sunpy.sun.constants as sconst
 from astropy.utils.data import get_pkg_data_filename
 from sunpy.coordinates import get_horizons_coord
 from tqdm.auto import tqdm
+from typing import Callable
 
 # Utilities toolbox, contains helpful functions
 
@@ -120,23 +121,75 @@ def k_legacy(mu: float, sigma: float, sigma_multiplier: float) -> float:
     return np.round(nominator/denominator)
 
 
-def sqrt_sum_squares(series):
+# def sqrt_sum_squares(series):
+#     """
+#     Custom aggregation function for uncertainties, which calculates the
+#     sqrt of the sum of squares divided by number of samples in the bin
+
+#     Parameters
+#     ----------
+#     series : pd.Series
+#         The series to aggregate
+
+#     Returns
+#     -------
+#     float
+#         Sqrt of sum of squares divided by number of samples
+#     """
+#     if isinstance(series, pd.DataFrame):
+#         custom_warning("The sqrt_sum_squares function is not tested for DataFrames yet! Proceed with caution and report any issues you find!")
+
+#     return np.sqrt(np.nansum(series**2)) / series.count()
+
+
+def rms_uncertainty(data: pd.Series | pd.DataFrame) -> float | pd.Series:
     """
-    Custom aggregation function for uncertainties, which calculates the
-    sqrt of the sum of squares divided by number of samples in the bin
+    Aggregation function for uncertainties, which calculates the square root
+    of the sum of squares divided by the number of samples in the bin.
+
+    This differs from the standard Root Mean Square (RMS), where the division
+    by n occurs *inside* the square root: sqrt(sum(x**2) / n). Here, the
+    division occurs *outside*: sqrt(sum(x**2)) / n. This form is appropriate
+    for propagating uncertainties when averaging n measurements.
+
+    Works for both pd.Series and pd.DataFrame. In the case of a DataFrame,
+    the calculation is performed per column.
 
     Parameters
     ----------
-    series : pd.Series
-        The series to aggregate
+    data : pd.Series or pd.DataFrame
+        The data to aggregate
 
     Returns
     -------
-    float
-        Sqrt of sum of squares divided by number of samples
-    """
+    float or pd.Series
+        Sqrt of sum of squares divided by number of samples.
+        Returns a single float for pd.Series input, or a pd.Series
+        (one value per column) for pd.DataFrame input.
+        Returns np.nan if the input is empty, all-NaN, or (for DataFrames)
+        for any column that is empty or all-NaN.
 
-    return np.sqrt(np.nansum(series**2)) / series.count()
+    Raises
+    ------
+    TypeError
+        If data is not a pd.Series or pd.DataFrame.
+    """
+    if isinstance(data, pd.Series):
+        count = data.count()
+        # Return np.nan early if count is zero (empty or all-NaN) to avoid division by zero
+        if count == 0:
+            return np.nan
+        return np.sqrt(np.nansum(data**2)) / count
+
+    elif isinstance(data, pd.DataFrame):
+        count = data.count()  # per-column Series
+        # Replace zero counts with np.nan before dividing to avoid division by zero
+        if (count == 0).any():
+            count = count.where(count > 0, other=np.nan)
+        return np.sqrt(np.nansum(data**2, axis=0)) / count
+
+    else:
+        raise TypeError(f"Expected pd.Series or pd.DataFrame, got {type(data).__name__}")
 
 
 def reduce_list_generic(original_list, placeholder="xx", seperator="_"):
@@ -181,7 +234,15 @@ def reduce_list_generic(original_list, placeholder="xx", seperator="_"):
     return sorted(list(patterns))
 
 
-def resample_df(df, resample, pos_timestamp="center", origin="start", cols_unc='auto', keywords_unc=['unc', 'err', 'sigma'], verbose=True):
+def resample_df(
+    df: pd.DataFrame | pd.Series,
+    resample: str,
+    pos_timestamp: str = "center",
+    origin: str = "start",
+    cols_unc: list[str] | str = 'auto',
+    keywords_unc: list[str] = ['unc', 'err', 'sigma'],
+    verbose: bool = True
+) -> pd.DataFrame | pd.Series:
     """
     Resamples a Pandas Dataframe or Series to a new frequency. Note that this is
     just a simple wrapper around the pandas resample function that is
@@ -243,20 +304,16 @@ def resample_df(df, resample, pos_timestamp="center", origin="start", cols_unc='
     # automatically detect columns with uncertainties if not provided
     if type(cols_unc) is str and cols_unc == 'auto':
         if isinstance(df, pd.DataFrame):
-            if type(df.columns) is not pd.core.indexes.multi.MultiIndex:
+            if type(df.columns) is not pd.MultiIndex:
                 # cols_unc = [col for col in df.columns if 'uncertainty' in col.lower() or 'err' in col.lower() or 'sigma' in col.lower()]
                 cols_unc = [col for col in df.columns if any(keyword.lower() in col.lower() for keyword in keywords_unc)]
-            elif type(df.columns) is pd.core.indexes.multi.MultiIndex:
+            elif type(df.columns) is pd.MultiIndex:
                 cols_unc = []
                 custom_warning("\nResampling of MultiIndex DataFrames with uncertainty columns not implemented yet! Proceeding without uncertainty handling.\n")
         elif isinstance(df, pd.Series):
-            try:
-                # if 'unc' in df.name.lower() or 'error' in df.name.lower():
-                if any(keyword.lower() in df.name.lower() for keyword in keywords_unc):
-                    cols_unc = [df.name]
-                else:
-                    cols_unc = []
-            except AttributeError:
+            if isinstance(df.name, str) and any(keyword.lower() in df.name.lower() for keyword in keywords_unc):
+                cols_unc = [df.name]
+            else:
                 cols_unc = []
         if len(cols_unc) > 0 and cols_unc != 'auto':
             if verbose:
@@ -271,7 +328,7 @@ def resample_df(df, resample, pos_timestamp="center", origin="start", cols_unc='
             # save column order
             df_columns = df.columns
             #
-            agg_dict = {col: sqrt_sum_squares for col in cols_unc}
+            agg_dict: dict[str, Callable[..., float | pd.Series] | str] = {col: rms_uncertainty for col in cols_unc}
             for col in df.columns.difference(cols_unc):
                 agg_dict[col] = 'mean'
             df = df.resample(resample, origin=origin, label="left").agg(agg_dict)
@@ -279,8 +336,8 @@ def resample_df(df, resample, pos_timestamp="center", origin="start", cols_unc='
             df = df[df_columns]
         # Handle Series input
         elif isinstance(df, pd.Series):
-            if df.name in cols_unc:
-                df = df.resample(resample, origin=origin, label="left").agg(sqrt_sum_squares)
+            if isinstance(df.name, str) and df.name in cols_unc:
+                df = df.resample(resample, origin=origin, label="left").agg(rms_uncertainty)
             else:
                 df = df.resample(resample, origin=origin, label="left").mean()  # This is actually the original functionality before adding cols_unc
         # Adjust timestamp position

--- a/seppy/util/__init__.py
+++ b/seppy/util/__init__.py
@@ -142,7 +142,7 @@ def k_legacy(mu: float, sigma: float, sigma_multiplier: float) -> float:
 #     return np.sqrt(np.nansum(series**2)) / series.count()
 
 
-def rms_uncertainty(data: pd.Series | pd.DataFrame) -> float | pd.Series:
+def propagated_mean_uncertainty(data: pd.Series | pd.DataFrame) -> float | pd.Series:
     """
     Aggregation function for uncertainties, which calculates the square root
     of the sum of squares divided by the number of samples in the bin.
@@ -328,7 +328,7 @@ def resample_df(
             # save column order
             df_columns = df.columns
             #
-            agg_dict: dict[str, Callable[..., float | pd.Series] | str] = {col: rms_uncertainty for col in cols_unc}
+            agg_dict: dict[str, Callable[..., float | pd.Series] | str] = {col: propagated_mean_uncertainty for col in cols_unc}
             for col in df.columns.difference(cols_unc):
                 agg_dict[col] = 'mean'
             df = df.resample(resample, origin=origin, label="left").agg(agg_dict)
@@ -337,7 +337,7 @@ def resample_df(
         # Handle Series input
         elif isinstance(df, pd.Series):
             if isinstance(df.name, str) and df.name in cols_unc:
-                df = df.resample(resample, origin=origin, label="left").agg(rms_uncertainty)
+                df = df.resample(resample, origin=origin, label="left").agg(propagated_mean_uncertainty)
             else:
                 df = df.resample(resample, origin=origin, label="left").mean()  # This is actually the original functionality before adding cols_unc
         # Adjust timestamp position


### PR DESCRIPTION
This pull request refactors and improves the uncertainty aggregation logic in the `seppy/util/__init__.py` utilities, focusing on more robust and clear handling of uncertainty columns during DataFrame and Series resampling. The changes include replacing the old `sqrt_sum_squares` function with a more general and well-documented `propagated_mean_uncertainty` function, updating type annotations, and improving automatic detection and aggregation of uncertainty columns.

**Uncertainty aggregation improvements:**

* Introduced a new `propagated_mean_uncertainty` function to replace the previous `sqrt_sum_squares`, providing better documentation, type safety, and correct handling for both `pd.Series` and `pd.DataFrame` inputs. This function properly returns `np.nan` for empty/all-NaN data and raises a `TypeError` for unsupported types.
* Updated the resampling logic in `resample_df` to use the new `propagated_mean_uncertainty` function for columns detected as uncertainties, improving aggregation accuracy and maintainability.

**Type annotation and detection enhancements:**

* Added and improved type annotations for `resample_df` parameters and variables, clarifying expected input and output types.
* Improved automatic detection of uncertainty columns for both DataFrames and Series, including better handling of `MultiIndex` columns and more robust string checks.

**General code quality:**

* Added missing import for `Callable` from `typing` to support new type annotations.