### PR TITLE
Enhance download functionality and error handling in wind.py

### DIFF
--- a/seppy/loader/wind.py
+++ b/seppy/loader/wind.py
@@ -21,6 +21,14 @@ logger = pooch.get_logger()
 logger.setLevel("WARNING")
 
 
+def _download_file(url, fname, path):
+    try:
+        downloaded_file = pooch.retrieve(url=url, known_hash=None, fname=fname, path=path, progressbar=True)
+    except ModuleNotFoundError:
+        downloaded_file = pooch.retrieve(url=url, known_hash=None, fname=fname, path=path, progressbar=False)
+    return downloaded_file
+
+
 def _download_metafile(dataset, path=None):
     """
     Download master cdf file from cdaweb for 'dataset'
@@ -28,12 +36,15 @@ def _download_metafile(dataset, path=None):
     if not path:
         path = sunpy.config.get('downloads', 'sample_dir')
     base_url = 'https://spdf.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/'
+    base_url_mirror = 'https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/'
     fname = dataset.lower() + '_00000000_v01.cdf'
     url = base_url + fname
+    url_mirror = base_url_mirror + fname
     try:
-        downloaded_file = pooch.retrieve(url=url, known_hash=None, fname=fname, path=path, progressbar=True)
-    except ModuleNotFoundError:
-        downloaded_file = pooch.retrieve(url=url, known_hash=None, fname=fname, path=path, progressbar=False)
+        downloaded_file = _download_file(url=url, fname=fname, path=path)
+    except requests.exceptions.ReadTimeout:
+        print(f'Unable to download master file from {url} due to timeout. Trying mirror site...')
+        downloaded_file = _download_file(url=url_mirror, fname=fname, path=path)
     #
     return downloaded_file
 

--- a/seppy/loader/wind.py
+++ b/seppy/loader/wind.py
@@ -42,8 +42,8 @@ def _download_metafile(dataset, path=None):
     url_mirror = base_url_mirror + fname
     try:
         downloaded_file = _download_file(url=url, fname=fname, path=path)
-    except requests.exceptions.ReadTimeout:
-        print(f'Unable to download master file from {url} due to timeout. Trying mirror site...')
+    except requests.exceptions.RequestException:
+        print(f'Unable to download CDF master file from {url}. Trying mirror site...')
         downloaded_file = _download_file(url=url_mirror, fname=fname, path=path)
     #
     return downloaded_file


### PR DESCRIPTION
This pull request refactors the file download logic in `seppy/loader/wind.py` to improve code reuse and robustness. The main improvement is the introduction of a helper function for downloading files, and the addition of a fallback mechanism to download from a mirror site if the primary site fails.

File download improvements:

* Added a new `_download_file` helper function to encapsulate the file download logic, including handling the absence of the `tqdm` module by toggling the progress bar.
* Updated `_download_metafile` to use `_download_file` and added a fallback to download from a mirror URL if the primary download fails due to a `requests.exceptions.RequestException`.