### PR TITLE
Bump version to 0.4.4 and update release date in CITATION.cff and ver…

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,8 +37,8 @@ authors:
   family-names: Vainio
   affiliation: University of Turku
   orcid: https://orcid.org/0000-0002-3298-2067
-version: 0.4.3
-date-released: 2026-01-23
+version: 0.4.4
+date-released: 2026-04-15
 repository-code: https://github.com/serpentine-h2020/SEPpy
 license: BSD-3-Clause
 preferred-citation:

--- a/seppy/version.py
+++ b/seppy/version.py
@@ -14,4 +14,4 @@ except Exception:
     )
     del warnings
 
-    version = '0.4.3'
+    version = '0.4.4'


### PR DESCRIPTION
This pull request updates the project version from 0.4.3 to 0.4.4. The version bump is reflected in both the `CITATION.cff` metadata and the `seppy/version.py` file, along with an updated release date.

Version update:

* Bumped the version number to `0.4.4` and updated the release date in `CITATION.cff`.
* Updated the version string to `0.4.4` in `seppy/version.py`.…sion.py