### PR TITLE
Update pyproject.toml to not include test files in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,16 @@ repository = "https://github.com/serpentine-h2020/SEPpy"
 
 [tool.setuptools]
 zip-safe = false
-include-package-data = true
+include-package-data = false
+
+[tool.setuptools.package-data]
+seppy = [
+    "data/bepi_sixsp_instrumental_constants/**/*",
+]
 
 [tool.setuptools.packages.find]
 include = ["seppy*"]
-exclude = ["seppy._dev*"]
+exclude = ["seppy._dev*", "seppy.tests*"]
 
 [tool.setuptools_scm]
 version_file = "seppy/_version.py"


### PR DESCRIPTION
This pull request updates the packaging configuration in `pyproject.toml` to refine how package data is included and which subpackages are distributed. The main changes focus on improving package data management and excluding test modules from distribution.

**Packaging configuration improvements:**

* Set `include-package-data` to `false` and explicitly specified package data to include only the `seppy/data/bepi_sixsp_instrumental_constants/**/*` directory, ensuring only necessary data files are packaged.
* Updated the package discovery settings to also exclude the `seppy.tests*` package, preventing test code from being included in distributed builds.