### PR TITLE
Refactor test file paths and add GitHub Actions for wheel testing

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -64,3 +64,37 @@ jobs:
       uses: codecov/codecov-action@v6
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  test-wheel:
+    if: github.event_name == 'pull_request'
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+    - name: Build wheel
+      run: |
+        uv venv .venv --python ${{ matrix.python-version }}
+        source .venv/bin/activate
+        uv pip install build
+        python -m build
+    - name: Install from wheel
+      run: |
+        source .venv/bin/activate
+        uv pip install nbmake pytest pytest-doctestplus pytest-cov
+        uv pip install dist/seppy-*.whl
+    - name: Test with pytest
+      run: |
+        source .venv/bin/activate
+        mv seppy seppy_src
+        pytest seppy_src/tests/

--- a/seppy/tests/test_loader.py
+++ b/seppy/tests/test_loader.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests
-from astropy.utils.data import get_pkg_data_filename
+# from astropy.utils.data import get_pkg_data_filename
 from pathlib import Path
 from seppy.loader.bepi import bepi_sixsp_l3_loader
 from seppy.loader.juice import juice_radem_load
@@ -140,8 +140,9 @@ def test_soho_ephin_l2_load_online():
 
 
 def test_soho_ephin_l2_load_offline():
-    fullpath = get_pkg_data_filename('data/test/epi21106.rl2', package='seppy')
-    path = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/epi21106.rl2', package='seppy')
+    # path = Path(fullpath).parent.as_posix()
+    path = (Path(__file__).parent.parent / "data" / "test").as_posix()
     df, meta = soho_load(dataset='SOHO_COSTEP-EPHIN_L2-1MIN', startdate="2021/04/16", enddate="2021/04/16",
                          path=path, resample="2min", pos_timestamp=None)
     assert isinstance(df, pd.DataFrame)
@@ -189,8 +190,9 @@ def test_solo_mag_load_online():
 
 def test_solo_mag_load_offline():
     # offline data files need to be replaced if data "version" is updated!
-    fullpath = get_pkg_data_filename('data/test/solo_l2_mag-rtn-normal-1-minute_20210712_v01.cdf', package='seppy')
-    path = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/solo_l2_mag-rtn-normal-1-minute_20210712_v01.cdf', package='seppy')
+    # path = Path(fullpath).parent.as_posix()
+    path = (Path(__file__).parent.parent / "data" / "test").as_posix()
     df = mag_load("2021/07/12", "2021/07/13", level='l2', data_type='normal-1-minute', frame='rtn', path=path)
     assert isinstance(df, pd.DataFrame)
     assert df.shape == (1437, 7)
@@ -208,8 +210,9 @@ def test_stereo_het_load_online():
 
 def test_stereo_het_load_offline():
     # offline data files need to be replaced if data "version" is updated!
-    fullpath = get_pkg_data_filename('data/test/sta_l1_het_20211028_v01.cdf', package='seppy')
-    path = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/sta_l1_het_20211028_v01.cdf', package='seppy')
+    # path = Path(fullpath).parent.as_posix()
+    path = (Path(__file__).parent.parent / "data" / "test").as_posix()
     df, meta = stereo_load(instrument="HET", startdate="2021/10/28", enddate="2021/10/29",
                            path=path, resample="1min", pos_timestamp=None)
     assert isinstance(df, pd.DataFrame)
@@ -230,8 +233,9 @@ def test_stereo_sept_load_online():
 
 def test_stereo_sept_load_offline():
     # offline data files need to be replaced if data "version" is updated!
-    fullpath = get_pkg_data_filename('data/test/sept_ahead_ele_sun_2006_318_1min_l2_v03.dat', package='seppy')
-    path = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/sept_ahead_ele_sun_2006_318_1min_l2_v03.dat', package='seppy')
+    # path = Path(fullpath).parent.as_posix()
+    path = (Path(__file__).parent.parent / "data" / "test").as_posix()
     df, meta = stereo_load(instrument="SEPT", startdate="2006/11/14", enddate="2006/11/14",
                            path=path, resample="1min", pos_timestamp=None, sept_viewing='sun')
     assert isinstance(df, pd.DataFrame)
@@ -257,8 +261,9 @@ def test_wind3dp_load_online():
 
 def test_wind3dp_load_offline():
     # offline data files need to be replaced if data "version" is updated!
-    fullpath = get_pkg_data_filename('data/test/wi_sfsp_3dp_20200213_v01.cdf', package='seppy')
-    path = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/wi_sfsp_3dp_20200213_v01.cdf', package='seppy')
+    # path = Path(fullpath).parent.as_posix()
+    path = (Path(__file__).parent.parent / "data" / "test").as_posix()
     df, meta = wind3dp_load(dataset="WI_SFSP_3DP",
                             startdate="2020/02/13",
                             enddate="2020/02/14",

--- a/seppy/tests/test_tools.py
+++ b/seppy/tests/test_tools.py
@@ -1,4 +1,4 @@
-from astropy.utils.data import get_pkg_data_filename
+# from astropy.utils.data import get_pkg_data_filename
 from pathlib import Path
 from seppy.loader.stereo import stereo_load
 from seppy.tools import Event
@@ -557,8 +557,9 @@ def test_onset_spectrum_tsa_SOHO_ERNE_online():
 def test_onset_tsa_SOHO_ERNE_offline():
     startdate = datetime.date(2021, 10, 28)
     enddate = datetime.date(2021, 10, 29)
-    fullpath = get_pkg_data_filename('data/test/soho_erne-hed_l2-1min_20211028_v01.cdf', package='seppy')
-    lpath = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/soho_erne-hed_l2-1min_20211028_v01.cdf', package='seppy')
+    # lpath = Path(fullpath).parent.as_posix()
+    lpath = (Path(__file__).parent.parent / "data" / "test").as_posix()
     Event1 = Event(spacecraft='SOHO', sensor='ERNE-HED', data_level='l2', species='protons', start_date=startdate, end_date=enddate, data_path=lpath)
     print(Event1.print_energies())
     background_range = (datetime.datetime(2021, 10, 28, 10, 0, 0), datetime.datetime(2021, 10, 28, 12, 0, 0))
@@ -583,8 +584,9 @@ def test_onset_tsa_SOHO_ERNE_offline():
 def test_dynamic_spectrum_SOHO_ERNE_offline():
     startdate = datetime.date(2021, 10, 28)
     enddate = datetime.date(2021, 10, 29)
-    fullpath = get_pkg_data_filename('data/test/soho_erne-hed_l2-1min_20211028_v01.cdf', package='seppy')
-    lpath = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/soho_erne-hed_l2-1min_20211028_v01.cdf', package='seppy')
+    # lpath = Path(fullpath).parent.as_posix()
+    lpath = (Path(__file__).parent.parent / "data" / "test").as_posix()
     radio_spacecraft = None  # use ('ahead', 'STEREO-A') if #27 is fixed and radio files can be provided offline
     Event1 = Event(spacecraft='SOHO', sensor='ERNE-HED', data_level='l2', species='protons', start_date=startdate, end_date=enddate, data_path=lpath, radio_spacecraft=radio_spacecraft)
     Event1.dynamic_spectrum(view=None)
@@ -596,9 +598,10 @@ def test_dynamic_spectrum_SOHO_ERNE_offline():
 def test_onset_Bepi_SIXS_L2_offline():
     startdate = datetime.date(2023, 7, 19)
     enddate = datetime.date(2023, 7, 19)
-    fullpath = get_pkg_data_filename('data/test/20230719_side1.csv', package='seppy')
-    lpath = Path(fullpath).parent.as_posix()
+    # fullpath = get_pkg_data_filename('data/test/20230719_side1.csv', package='seppy')
+    # lpath = Path(fullpath).parent.as_posix()
     # lpath = '/home/jagies/data/bepi/bc_mpo_sixs/data_csv/cruise/sixs-p/raw'
+    lpath = (Path(__file__).parent.parent / "data" / "test").as_posix()
     Event1 = Event(spacecraft='Bepi', sensor='SIXS-P', data_level='l2', species='electrons', start_date=startdate, end_date=enddate, data_path=lpath, viewing='1')
     background_range = (datetime.datetime(2023, 7, 19, 0, 30, 0), datetime.datetime(2023, 7, 19, 1, 30, 0))
     flux, onset_stats, onset_found, peak_flux, peak_time, fig, bg_mean = Event1.find_onset(viewing='1', background_range=background_range, channels=2, resample_period="1min", yscale='log', cusum_window=30)


### PR DESCRIPTION
This pull request focuses on improving the reliability and portability of offline test cases and enhances the CI workflow to ensure wheel builds are tested across multiple Python versions. The most significant changes are grouped below.

**Testing and CI improvements**

* Added a new `test-wheel` job to the GitHub Actions workflow (`.github/workflows/pytest.yml`) to build and test the project wheel on Python versions 3.10 through 3.14, ensuring compatibility across future Python releases.

**Test code modernization and portability**

* Refactored all offline test cases in `seppy/tests/test_loader.py` and `seppy/tests/test_tools.py` to use a direct `Path` construction for test data directories instead of `astropy.utils.data.get_pkg_data_filename`, improving test portability and removing the dependency on Astropy for test data location. [[1]](diffhunk://#diff-b12f5c2060183dc753f93646ea05ce900904b79268ba0ee39ca1f4e889a755d9L6-R6) [[2]](diffhunk://#diff-b12f5c2060183dc753f93646ea05ce900904b79268ba0ee39ca1f4e889a755d9L143-R145) [[3]](diffhunk://#diff-b12f5c2060183dc753f93646ea05ce900904b79268ba0ee39ca1f4e889a755d9L192-R195) [[4]](diffhunk://#diff-b12f5c2060183dc753f93646ea05ce900904b79268ba0ee39ca1f4e889a755d9L211-R215) [[5]](diffhunk://#diff-b12f5c2060183dc753f93646ea05ce900904b79268ba0ee39ca1f4e889a755d9L233-R238) [[6]](diffhunk://#diff-b12f5c2060183dc753f93646ea05ce900904b79268ba0ee39ca1f4e889a755d9L260-R266) [[7]](diffhunk://#diff-9c7c7120d15d2214af4aa0917f24180f36e3684874cc018f2dafc14b7864a18bL1-R1) [[8]](diffhunk://#diff-9c7c7120d15d2214af4aa0917f24180f36e3684874cc018f2dafc14b7864a18bL560-R562) [[9]](diffhunk://#diff-9c7c7120d15d2214af4aa0917f24180f36e3684874cc018f2dafc14b7864a18bL586-R589) [[10]](diffhunk://#diff-9c7c7120d15d2214af4aa0917f24180f36e3684874cc018f2dafc14b7864a18bL599-R604)