### PR TITLE
Fix resampling for non-numeric columns; correctly resample PSP/ISOIS/EPILO-PE electron fluxes

### DIFF
--- a/seppy/loader/psp.py
+++ b/seppy/loader/psp.py
@@ -230,8 +230,8 @@ def psp_isois_load(dataset, startdate, enddate, epilo_channel='F', epilo_thresho
 
         if isinstance(resample, str):
             if dataset.upper() in ['PSP_ISOIS-EPILO_L2-PE']:
-                cols_unc = []
-                keywords_unc = []
+                cols_unc = 'auto'
+                keywords_unc = ['_DELTA_E']  # uncertainty columns for EPILO PE have '_DELTA_E' in their name, e.g. 'Electron_Flux_ChanE_DELTA_E47_P6'. There is also 'Epoch_ChanE_DELTA' column for the time uncertainty, but this should not be resampled with the same method as the flux uncertainties, so it is not included here.
             elif dataset.upper() in ['PSP_ISOIS-EPIHI_L2-HET-RATES60', 'PSP_ISOIS-EPIHI_L2-LET1-RATES60', 'PSP_ISOIS-EPIHI_L2-LET2-RATES60', 'PSP_ISOIS-EPILO_L2-IC']:
                 cols_unc = 'auto'
                 keywords_unc=['unc', 'err', 'sigma', '_DELTA_']  # 'PSP_ISOIS-EPILO_L2-IC' has 'H_Flux_ChanP_DELTA_Exx_Pxx' uncertainty columns
@@ -347,7 +347,12 @@ def calc_av_en_flux_PSP_EPILO(df, en_dict, en_channel, species, mode, chan, view
     if mode.lower() == 'pe':
         if species.lower() in ['e', 'electrons']:
             species_str = 'Electron'
-            flux_key = 'Electron_CountRate'
+            # check if electron flux columns are in the dataframe, because they are (so far) only available for chanE!
+            # fall back to count rates if not available
+            if 'Electron_Flux_Chan{chan}_E0_P0' in df.keys():
+                flux_key = 'Electron_Flux'
+            else:
+                flux_key = 'Electron_CountRate'
         # if species.lower() in ['p', 'protons', 'i', 'ions', 'h']:
         #     species_str = 'H'
         #     flux_key = 'H_Flux'
@@ -404,7 +409,7 @@ def calc_av_en_flux_PSP_EPILO(df, en_dict, en_channel, species, mode, chan, view
             df_out = pd.concat([df_out, flux_out], axis=1)
 
         # calculate mean of all viewings:
-        df_out2 = pd.DataFrame({'flux': df_out.mean(axis=1, skipna=True)}, index=df_out.index)
+        df_out2 = pd.DataFrame({flux_key: df_out.mean(axis=1, skipna=True)}, index=df_out.index)
         en_channel_string_all.append(en_channel_string)
 
     # check if not all elements of en_channel_string_all are the same:

--- a/seppy/loader/psp.py
+++ b/seppy/loader/psp.py
@@ -347,12 +347,16 @@ def calc_av_en_flux_PSP_EPILO(df, en_dict, en_channel, species, mode, chan, view
     if mode.lower() == 'pe':
         if species.lower() in ['e', 'electrons']:
             species_str = 'Electron'
-            # check if electron flux columns are in the dataframe, because they are (so far) only available for chanE!
-            # fall back to count rates if not available
-            if 'Electron_Flux_Chan{chan}_E0_P0' in df.keys():
-                flux_key = 'Electron_Flux'
-            else:
-                flux_key = 'Electron_CountRate'
+            flux_key = 'Electron_CountRate'
+
+            # TODO: the following is for introducing electron fluxes instead of countates
+            # # check if electron flux columns are in the dataframe, because they are (so far) only available for chanE!
+            # # fall back to count rates if not available
+            # if 'Electron_Flux_Chan{chan}_E0_P0' in df.keys():
+            #     flux_key = 'Electron_Flux'
+            # else:
+            #     flux_key = 'Electron_CountRate'
+
         # if species.lower() in ['p', 'protons', 'i', 'ions', 'h']:
         #     species_str = 'H'
         #     flux_key = 'H_Flux'
@@ -409,7 +413,8 @@ def calc_av_en_flux_PSP_EPILO(df, en_dict, en_channel, species, mode, chan, view
             df_out = pd.concat([df_out, flux_out], axis=1)
 
         # calculate mean of all viewings:
-        df_out2 = pd.DataFrame({flux_key: df_out.mean(axis=1, skipna=True)}, index=df_out.index)
+        df_out2 = pd.DataFrame({'flux': df_out.mean(axis=1, skipna=True)}, index=df_out.index)
+        # df_out2 = pd.DataFrame({flux_key: df_out.mean(axis=1, skipna=True)}, index=df_out.index)  # TODO: introduce flux_key into column name to distinguish between electron countrate and flux
         en_channel_string_all.append(en_channel_string)
 
     # check if not all elements of en_channel_string_all are the same:

--- a/seppy/util/__init__.py
+++ b/seppy/util/__init__.py
@@ -344,13 +344,13 @@ def resample_df(
             # restore column order (only for columns that survived resampling)
             df = df[[col for col in df_columns if col in df.columns]]
 
-        # Check for non-numeric columns that were dropped during resampling and print a warning if verbose is True
-        dropped_cols = [col for col in df_columns if col not in non_object_cols]
-        if dropped_cols: 
-            if not verbose:
-                custom_warning(f"The following non-numeric columns were dropped during resampling: {dropped_cols}")
-            else: 
-                custom_warning("Some non-numeric columns were dropped during resampling.")
+            # Check for non-numeric columns that were dropped during resampling and print a warning if verbose is True
+            dropped_cols = [col for col in df_columns if col not in non_object_cols]
+            if dropped_cols: 
+                if not verbose:
+                    custom_warning(f"The following non-numeric columns were dropped during resampling: {dropped_cols}")
+                else: 
+                    custom_warning("Some non-numeric columns were dropped during resampling.")
         # Handle Series input
         elif isinstance(df, pd.Series):
             if isinstance(df.name, str) and df.name in cols_unc:

--- a/seppy/util/__init__.py
+++ b/seppy/util/__init__.py
@@ -327,13 +327,29 @@ def resample_df(
         if isinstance(df, pd.DataFrame):
             # save column order
             df_columns = df.columns
-            #
-            agg_dict: dict[str, Callable[..., float | pd.Series] | str] = {col: propagated_mean_uncertainty for col in cols_unc}
+            # Identify numeric columns only
+            numeric_cols = df.select_dtypes(include='number').columns
+            
+            agg_dict: dict[str, Callable[..., float | pd.Series] | str] = {}
+            for col in cols_unc:
+                if col in numeric_cols:  # only add uncertainty cols if they are numeric
+                    agg_dict[col] = propagated_mean_uncertainty
             for col in df.columns.difference(cols_unc):
-                agg_dict[col] = 'mean'
+                if col in numeric_cols:  # only add non-uncertainty cols if they are numeric
+                    agg_dict[col] = 'mean'
+            
             df = df.resample(resample, origin=origin, label="left").agg(agg_dict)
-            # restore column order
-            df = df[df_columns]
+            
+            # restore column order (only for columns that survived resampling)
+            df = df[[col for col in df_columns if col in df.columns]]
+
+        # Check for non-numeric columns that were dropped during resampling and print a warning if verbose is True
+        dropped_cols = [col for col in df_columns if col not in numeric_cols]
+        if dropped_cols: 
+            if verbose:
+                custom_warning(f"The following non-numeric columns were dropped during resampling: {dropped_cols}")
+            else: 
+                custom_warning(f"Some non-numeric columns were dropped during resampling.")
         # Handle Series input
         elif isinstance(df, pd.Series):
             if isinstance(df.name, str) and df.name in cols_unc:

--- a/seppy/util/__init__.py
+++ b/seppy/util/__init__.py
@@ -327,29 +327,30 @@ def resample_df(
         if isinstance(df, pd.DataFrame):
             # save column order
             df_columns = df.columns
-            # Identify numeric columns only
-            numeric_cols = df.select_dtypes(include='number').columns
-            
+
+            # Identify non-object columns (this includes numeric columns but also datetime columns, etc.) to avoid resampling of object columns (such as strings), which would raise errors.
+            non_object_cols = df.select_dtypes(exclude='object').columns
+
             agg_dict: dict[str, Callable[..., float | pd.Series] | str] = {}
             for col in cols_unc:
-                if col in numeric_cols:  # only add uncertainty cols if they are numeric
+                if col in non_object_cols:
                     agg_dict[col] = propagated_mean_uncertainty
             for col in df.columns.difference(cols_unc):
-                if col in numeric_cols:  # only add non-uncertainty cols if they are numeric
+                if col in non_object_cols:
                     agg_dict[col] = 'mean'
-            
+
             df = df.resample(resample, origin=origin, label="left").agg(agg_dict)
-            
+
             # restore column order (only for columns that survived resampling)
             df = df[[col for col in df_columns if col in df.columns]]
 
         # Check for non-numeric columns that were dropped during resampling and print a warning if verbose is True
-        dropped_cols = [col for col in df_columns if col not in numeric_cols]
+        dropped_cols = [col for col in df_columns if col not in non_object_cols]
         if dropped_cols: 
-            if verbose:
+            if not verbose:
                 custom_warning(f"The following non-numeric columns were dropped during resampling: {dropped_cols}")
             else: 
-                custom_warning(f"Some non-numeric columns were dropped during resampling.")
+                custom_warning("Some non-numeric columns were dropped during resampling.")
         # Handle Series input
         elif isinstance(df, pd.Series):
             if isinstance(df.name, str) and df.name in cols_unc:

--- a/seppy/util/__init__.py
+++ b/seppy/util/__init__.py
@@ -347,7 +347,7 @@ def resample_df(
             # Check for non-numeric columns that were dropped during resampling and print a warning if verbose is True
             dropped_cols = [col for col in df_columns if col not in non_object_cols]
             if dropped_cols: 
-                if not verbose:
+                if verbose:
                     custom_warning(f"The following non-numeric columns were dropped during resampling: {dropped_cols}")
                 else: 
                     custom_warning("Some non-numeric columns were dropped during resampling.")


### PR DESCRIPTION
This pull request addresses https://github.com/serpentine-h2020/SEPpy/issues/122. It improves the handling of uncertainty columns and the resampling process in the PSP/ISOIS data loader for the EPILO PE dataset, and adds safeguards to prevent errors when resampling DataFrames with non-numeric columns. The main changes focus on making the resampling function more robust, clarifying which uncertainty columns are selected, and preparing the code for future support of electron flux data.

**Enhancements to resampling and uncertainty handling:**

* Improved the logic for selecting uncertainty columns in `psp_isois_load`: for the EPILO PE dataset, `cols_unc` is now set to `'auto'` and `keywords_unc` is set to `['_DELTA_E']`, ensuring only the correct uncertainty columns are selected and avoiding resampling time uncertainty columns incorrectly.
* Updated the `resample_df` function to only apply aggregation to non-object (typically numeric) columns, preventing errors from attempting to resample string or object columns. It also now warns if non-numeric columns are dropped during resampling.

**Preparations for future data support:**

* Added TODO comments and preliminary code in `calc_av_en_flux_PSP_EPILO` to support electron flux columns (not just count rates), allowing for future extension when these columns become available. [[1]](diffhunk://#diff-f22c7c4a65238338bd962c1a9af5d2f8e7f2ac75b815b007a182a1a9865c219fR351-R359) [[2]](diffhunk://#diff-f22c7c4a65238338bd962c1a9af5d2f8e7f2ac75b815b007a182a1a9865c219fR417)