### PR TITLE
Bump version to 0.4.5 and update release date in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,8 +37,8 @@ authors:
   family-names: Vainio
   affiliation: University of Turku
   orcid: https://orcid.org/0000-0002-3298-2067
-version: 0.4.4
-date-released: 2026-04-15
+version: 0.4.5
+date-released: 2026-05-25
 repository-code: https://github.com/serpentine-h2020/SEPpy
 license: BSD-3-Clause
 preferred-citation:

--- a/seppy/version.py
+++ b/seppy/version.py
@@ -14,4 +14,4 @@ except Exception:
     )
     del warnings
 
-    version = '0.4.4'
+    version = '0.4.5'


### PR DESCRIPTION
This pull request updates the project version from `0.4.4` to `0.4.5` across the codebase. The version bump is reflected in both the `CITATION.cff` metadata and the `seppy/version.py` file.

Version update:

* Updated the `version` field to `0.4.5` and the `date-released` to `2026-05-25` in `CITATION.cff`.
* Updated the `version` variable to `0.4.5` in `seppy/version.py`.