### PR TITLE
Update SOHO instrument list and enhance EPHIN data warnings

### DIFF
--- a/seppy/loader/soho.py
+++ b/seppy/loader/soho.py
@@ -370,7 +370,7 @@ def soho_ephin_loader(startdate, enddate, resample=None, path=None, all_columns=
             # # warnings.warn("Proton and helium data is still uncorrected! Know what you're doing and use at own risk!")
             custom_warning("SOHO/EPHIN proton and helium data is still uncorrected! Know what you're doing and use at own risk!")
         else:
-            custom_notification("SOHO/EPHIN proton and helium data are not supported at the moment and set to negative values of -9e9!")
+            custom_notification("SOHO/EPHIN RL2 proton and helium data are not supported at the moment and set to negative values of -9e9!")
             df.P4 = -9e9
             df.P8 = -9e9
             df.P25 = -9e9
@@ -450,6 +450,11 @@ def soho_ephin_loader(startdate, enddate, resample=None, path=None, all_columns=
                 'H41': '40.9 - 53.0 MeV/n',
                 'INT': '>25 MeV integral'}
     meta = {'energy_labels': energies}
+
+    BOLD = "\033[1m"
+    RED = "\033[31m"
+    RESET = "\033[0m"
+    custom_warning(f'SOHO/EPHIN RL2 electron data can be highly unreliable at times and {BOLD}{RED}SHOULD NOT BE USED!{RESET}')
 
     return df, meta
 

--- a/seppy/tools/widgets_onset.py
+++ b/seppy/tools/widgets_onset.py
@@ -12,7 +12,7 @@ list_of_sc = ["BepiColombo", "PSP", "SOHO", "Solar Orbiter", "STEREO-A", "STEREO
 stereo_instr = ["HET", "SEPT"]  # ["LET", "SEPT", "HET"]
 solo_instr = ["EPT", "HET", "STEP"]
 bepi_instr = ["SIXS-P"]
-soho_instr = ["EPHIN", "ERNE-HED"]
+soho_instr = ["ERNE-HED"]  # ["EPHIN", "ERNE-HED"]  # deactivate unreliable EPHIN electron data for now
 psp_instr = ["isois-epihi", "isois-epilo"]
 wind_instr = ["3DP"]
 

--- a/seppy/tools/widgets_tsa.py
+++ b/seppy/tools/widgets_tsa.py
@@ -12,7 +12,7 @@ list_of_sc = ["PSP", "SOHO", "Solar Orbiter", "STEREO-A", "STEREO-B", "Wind"]
 stereo_instr = ["HET", "SEPT"]  # ["LET", "SEPT", "HET"]
 solo_instr = ["EPT", "HET", "STEP"]
 bepi_instr = ["SIXS-P"]
-soho_instr = ["EPHIN", "ERNE-HED"]
+soho_instr = ["ERNE-HED"]  # ["EPHIN", "ERNE-HED"]  # deactivate unreliable EPHIN electron data for now
 psp_instr = ["isois-epihi", "isois-epilo"]
 wind_instr = ["3DP"]
 


### PR DESCRIPTION
This pull request addresses the handling of SOHO/EPHIN instrument data, specifically focusing on the reliability of its electron data and updating related notifications and tool configurations. The main changes include deactivating SOHO/EPHIN electron data in widgets due to reliability concerns, adding a clear warning about its unreliability, and clarifying notifications about unsupported data.

**SOHO/EPHIN electron data reliability and usage:**

* Added a prominent warning in `soho_ephin_loader` to inform users that SOHO/EPHIN RL2 electron data can be highly unreliable and should not be used. The message is styled for emphasis.
* Updated the notification message for unsupported proton and helium data to specify "RL2" data, providing more precise information to users.

**Widget configuration changes:**

* Deactivated SOHO/EPHIN in the `soho_instr` lists within both `widgets_onset.py` and `widgets_tsa.py`, effectively preventing the selection of unreliable EPHIN electron data in these tools. [[1]](diffhunk://#diff-4fde2e25090f44693ff323b61831536c40cbf603d10ae539d1f7d52a06adbfa7L15-R15) [[2]](diffhunk://#diff-65e9780b3da28858ae1af4886e4e090f4171c643d733d141b8fcfb7064860324L15-R15)