### PR TITLE
Enhance offline mode notifications with dataset references

### DIFF
--- a/seppy/loader/juice.py
+++ b/seppy/loader/juice.py
@@ -135,7 +135,7 @@ def juice_radem_load(startdate, enddate, resample=None, path=None, pos_timestamp
 
     if offline:
         custom_notification(
-            f'offline mode enabled, loading local files only from '
+            f'Offline mode enabled for JUICE/RADEM, loading local files only from '
             f'{path}. No check is performed whether newer versions '
             f'of the data files are available on the server.'
         )

--- a/seppy/loader/psp.py
+++ b/seppy/loader/psp.py
@@ -120,7 +120,7 @@ def psp_isois_load(dataset, startdate, enddate, epilo_channel='F', epilo_thresho
             else:
                 data_path = path
             custom_notification(
-                f'offline mode enabled, loading local files only from '
+                f'Offline mode enabled for PSP/ISOIS, loading local files only from '
                 f'{data_path}. No check is performed whether newer versions '
                 f'of the data files are available on the server.'
             )

--- a/seppy/loader/soho.py
+++ b/seppy/loader/soho.py
@@ -157,7 +157,7 @@ def soho_load(dataset, startdate, enddate, path=None, resample=None, pos_timesta
                 else:
                     data_path = path
                 custom_notification(
-                    f'offline mode enabled, loading local files only from '
+                    f'Offline mode enabled for SOHO/{dataset}, loading local files only from '
                     f'{data_path}. No check is performed whether newer versions '
                     f'of the data files are available on the server.'
                 )

--- a/seppy/loader/solo.py
+++ b/seppy/loader/solo.py
@@ -94,7 +94,7 @@ def mag_load(startdate, enddate, level='l2', data_type='normal', frame='rtn', pa
         else:
             data_path = path
         custom_notification(
-            f'offline mode enabled, loading local files only from '
+            f'Offline mode enabled for SolO/MAG, loading local files only from '
             f'{data_path}. No check is performed whether newer versions '
             f'of the data files are available on the server.'
         )

--- a/seppy/loader/stereo.py
+++ b/seppy/loader/stereo.py
@@ -201,11 +201,11 @@ def stereo_sept_loader(startdate, enddate, spacecraft, species, viewing, resampl
     if not path:
         path = sunpy.config.get('downloads', 'download_dir') + os.sep
 
-    # if offline:
-    #     custom_warning(
-    #         f'offline mode enabled, loading local files only from '
-    #         f'{path}. '
-    #     )
+    if offline:
+        custom_notification(
+            f'Offline mode enabled for STEREO/SEPT, loading local files only from '
+            f'{path}. '
+        )
 
     # create list of files to load:
     dates = pd.date_range(start=startdate, end=enddate, freq='D')
@@ -473,7 +473,7 @@ def stereo_load(instrument, startdate, enddate, spacecraft='ahead', mag_coord='R
                 else:
                     data_path = path
                 custom_notification(
-                    f'offline mode enabled, loading local files only from '
+                    f'Offline mode enabled for STEREO/{instrument.upper()}, loading local files only from '
                     f'{data_path}. No check is performed whether newer versions '
                     f'of the data files are available on the server.'
                 )

--- a/seppy/loader/wind.py
+++ b/seppy/loader/wind.py
@@ -295,7 +295,7 @@ def wind3dp_load(dataset, startdate, enddate, resample="1min", multi_index=True,
         else:
             data_path = path
         custom_notification(
-            f'offline mode enabled, loading local files only from '
+            f'Offline mode enabled for Wind/3DP, loading local files only from '
             f'{data_path}. No check is performed whether newer versions '
             f'of the data files are available on the server.'
         )


### PR DESCRIPTION
This pull request clarifies the offline mode notification messages across multiple data loader modules. Each loader now specifies the relevant mission and instrument in its offline mode notification, making it easier for users to identify which dataset the message refers to.

**Notification message improvements:**

* `seppy/loader/juice.py`, `juice_radem_load`: The offline mode notification now specifies "JUICE/RADEM" in the message.
* `seppy/loader/psp.py`, `psp_isois_load`: The notification now refers to "PSP/ISOIS".
* `seppy/loader/soho.py`, `soho_load`: The notification now includes "SOHO/{dataset}".
* `seppy/loader/solo.py`, `mag_load`: The notification now specifies "SolO/MAG".
* `seppy/loader/stereo.py`, `stereo_sept_loader`: Restores and updates the offline mode notification for "STEREO/SEPT".
* `seppy/loader/stereo.py`, `stereo_load`: The notification now specifies "STEREO/{instrument.upper()}".
* `seppy/loader/wind.py`, `wind3dp_load`: The notification now refers to "Wind/3DP".