### PR TITLE
Remove highest 3 channels from ERNE and bump version to 0.5.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,8 +37,8 @@ authors:
   family-names: Vainio
   affiliation: University of Turku
   orcid: https://orcid.org/0000-0002-3298-2067
-version: 0.5.0
-date-released: 2026-08-13
+version: 0.5.1
+date-released: 2026-08-19
 repository-code: https://github.com/serpentine-h2020/SEPpy
 license: BSD-3-Clause
 preferred-citation:

--- a/seppy/loader/soho.py
+++ b/seppy/loader/soho.py
@@ -74,7 +74,7 @@ def _get_metadata(dataset, path_to_cdf):
     return metadata
 
 
-def soho_load(dataset, startdate, enddate, path=None, resample=None, pos_timestamp='center', max_conn=5, offline=False):
+def soho_load(dataset, startdate, enddate, path=None, resample=None, pos_timestamp='center', max_conn=5, offline=False, use_uncorrected_data_on_own_risk=False):
     """
     Download CDF files via SunPy/Fido from CDAWeb for CELIAS, EPHIN, ERNE onboard SOHO
 
@@ -114,6 +114,10 @@ def soho_load(dataset, startdate, enddate, path=None, resample=None, pos_timesta
         performed whether newer versions of the data files are available on
         the server; the latest locally available version is used. By default
         False.
+    use_uncorrected_data_on_own_risk : bool, optional
+        If True, return for SOHO/ERNE-HED uncorrected proton and helium data.
+        If False, the highest three energy channels are set to NaN. By default
+        False. 
 
     Returns
     -------
@@ -207,6 +211,29 @@ def soho_load(dataset, startdate, enddate, path=None, resample=None, pos_timesta
                     cols_unc = 'auto'
                     keywords_unc = ['_sys_', '_stat_']
                 df = resample_df(df, resample, pos_timestamp=pos_timestamp, cols_unc=cols_unc, verbose=False, keywords_unc=keywords_unc)
+
+            # <-- Remove untrusty 3 highest energy channels of ERNE-HED. TODO: Undo this when the data has been corrected!
+            if dataset.upper() in ['SOHO_ERNE-HED_L2-1MIN', 'SOHO_ERNE-LED_L2-1MIN']:
+                if use_uncorrected_data_on_own_risk:
+                    custom_warning("SOHO/ERNE: Three highest proton and helium energy channels are uncorrected! Know what you're doing and use at own risk!")
+                else:
+                    custom_notification("SOHO/ERNE: Three highest proton and helium channels are not supported at the moment and removed!")
+                    cols_to_remove = [c for c in df.columns if c.endswith(('7', '8', '9'))]
+                    # df[cols_to_remove] = np.nan
+                    df = df.drop(columns=cols_to_remove)
+
+                    # Remove the highest 3 He and proton channels from metadata
+                    for key in ["He_E_label", "He_energy", "He_energy_delta",
+                                "P_E_label", "P_energy", "P_energy_delta"]:
+                        if key in metadata:
+                            metadata[key] = metadata[key][:-3]
+
+                    # Remove highest 3 rows in channel DataFrames
+                    for key in ["channels_dict_df_He", "channels_dict_df_p"]:
+                        if key in metadata:
+                            metadata[key] = metadata[key].iloc[:-3].copy()
+
+            # Remove untrusty 3 highest energy channels of ERNE-HED -->
         except (RuntimeError, IndexError):
             print(f'Unable to obtain "{dataset}" data!')
             downloaded_files = []

--- a/seppy/loader/soho.py
+++ b/seppy/loader/soho.py
@@ -213,7 +213,7 @@ def soho_load(dataset, startdate, enddate, path=None, resample=None, pos_timesta
                 df = resample_df(df, resample, pos_timestamp=pos_timestamp, cols_unc=cols_unc, verbose=False, keywords_unc=keywords_unc)
 
             # <-- Remove untrusty 3 highest energy channels of ERNE-HED. TODO: Undo this when the data has been corrected!
-            if dataset.upper() in ['SOHO_ERNE-HED_L2-1MIN', 'SOHO_ERNE-LED_L2-1MIN']:
+            if dataset.upper() in ['SOHO_ERNE-HED_L2-1MIN']:
                 if use_uncorrected_data_on_own_risk:
                     custom_warning("SOHO/ERNE: Three highest proton and helium energy channels are uncorrected! Know what you're doing and use at own risk!")
                 else:

--- a/seppy/tests/test_loader.py
+++ b/seppy/tests/test_loader.py
@@ -170,9 +170,9 @@ def test_soho_erne_hed_load_online():
     df, meta = soho_load(dataset='SOHO_ERNE-HED_L2-1MIN', startdate="2021/04/16", enddate="2021/04/17",
                          path=None, resample="1min", pos_timestamp='center', offline=OFFLINE)
     assert isinstance(df, pd.DataFrame)
-    assert df.shape == (1145, 41)
-    assert meta['channels_dict_df_p']['ch_strings'].iloc[9] == '100 - 130 MeV'
-    assert df['PHC_9'].sum() == 1295.0
+    assert df.shape == (1145, 29)
+    assert meta['channels_dict_df_p']['ch_strings'].iloc[0] == '13  - 16 MeV'
+    assert df['PHC_0'].sum() == 417.0
 
 
 def test_soho_erne_led_load_online():

--- a/seppy/tests/test_loader.py
+++ b/seppy/tests/test_loader.py
@@ -171,7 +171,7 @@ def test_soho_erne_hed_load_online():
                          path=None, resample="1min", pos_timestamp='center', offline=OFFLINE)
     assert isinstance(df, pd.DataFrame)
     assert df.shape == (1145, 29)
-    assert meta['channels_dict_df_p']['ch_strings'].iloc[0] == '13  - 16 MeV'
+    assert meta['channels_dict_df_p']['ch_strings'].iloc[0] == '13  - 16  MeV'
     assert df['PHC_0'].sum() == 417.0
 
 

--- a/seppy/tests/test_time_shift_analysis.ipynb
+++ b/seppy/tests/test_time_shift_analysis.ipynb
@@ -39,7 +39,15 @@
    "execution_count": null,
    "id": "2a6f4f3b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[91mWARNING: \u001b[0mBreaking changes in SEPpy v0.4.0: The metadata for SOHO/EPHIN, SOHO/ERNE, STEREO/SEPT, and Wind/3DP have changed! See https://github.com/serpentine-h2020/SEPpy/releases/tag/v0.4.0 for details. (You can ignore this if you do not invoke SEPpy manually.)\n"
+     ]
+    }
+   ],
    "source": [
     "from seppy.tools import Event\n",
     "import seppy.tools.widgets as w\n",
@@ -187,7 +195,7 @@
    "outputs": [],
    "source": [
     "# Select the channels to be plotted (first, last, step), end-exclusively (use None to choose all)\n",
-    "channels = (2, 8, 1) #(1, 11, 2)"
+    "channels = (2, 6, 1) #(1, 11, 2)"
    ]
   },
   {

--- a/seppy/version.py
+++ b/seppy/version.py
@@ -14,4 +14,4 @@ except Exception:
     )
     del warnings
 
-    version = '0.5.0'
+    version = '0.5.1'


### PR DESCRIPTION
This pull request adds a new safety feature for handling SOHO/ERNE-HED data in the `soho_load` function and introduces a minor version bump to `0.5.1`. The most important changes are grouped below:

**SOHO/ERNE-HED Data Handling:**

* Added a new parameter `use_uncorrected_data_on_own_risk` to `soho_load`, allowing users to explicitly opt in to receiving uncorrected proton and helium data from SOHO/ERNE-HED. By default, the highest three energy channels are removed for safety. [[1]](diffhunk://#diff-149b674afba5035106b967f6199d1b4f36e34ec57be48dc2d16c9a8f8e379c18L77-R77) [[2]](diffhunk://#diff-149b674afba5035106b967f6199d1b4f36e34ec57be48dc2d16c9a8f8e379c18R117-R120)
* Implemented logic to drop the highest three uncorrected energy channels from both the returned DataFrame and associated metadata unless the new parameter is set to `True`. This ensures users are warned about potential data quality issues.

**Version Update:**

* Bumped the project version from `0.5.0` to `0.5.1` in both `CITATION.cff` and `seppy/version.py` to reflect new changes. [[1]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295L40-R41) [[2]](diffhunk://#diff-536e39c1f4dd6cb057ebdca83a6dde4a2998ebe4dae7139d7af1cca6e61b1950L17-R17)